### PR TITLE
add setting for ldap_pwd_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Include the SSSD module and it will set up PAM and the nsswitch for local and LD
 
 <pre>
   class { 'sssd':
-    ldap_base => 'dc=mycompany,dc=com',
-    ldap_uri  => 'ldap://ldap1.mycompany.com, ldap://ldap2.mycompany.com',
+    ldap_base       => 'dc=mycompany,dc=com',
+    ldap_uri        => 'ldap://ldap1.mycompany.com, ldap://ldap2.mycompany.com',
+    ldap_pwd_policy => 'none',
   }
 </pre>
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,12 @@
 #   String.  Filter used to search for users
 #   Default: (&(objectclass=shadowaccount)(objectclass=posixaccount))
 #
+# [*ldap_pwd_policy*]
+#   String. Select the policy to evaluate the password expiration on
+#   the client side.
+#   Default: shadow (default for sssd is 'none')
+#   Valid options: none shadow mit_kerberos
+#
 # [*ldap_schema*]
 #   String. Specifies the Schema Type in use on the target LDAP server.
 #   Default: rfc2307
@@ -64,6 +70,7 @@ class sssd (
   $ldap_uri           = 'ldap://ldap.example.org',
   $ldap_access_filter = '(&(objectclass=shadowaccount)(objectclass=posixaccount))',
   $ldap_group_member  = 'uniquemember',
+  $ldap_pwd_policy    = 'shadow',
   $ldap_schema        = 'rfc2307',
   $ldap_tls_reqcert   = 'demand',
   $ldap_tls_cacert    = '/etc/pki/tls/certs/ca-bundle.crt',

--- a/spec/classes/sssd_config_spec.rb
+++ b/spec/classes/sssd_config_spec.rb
@@ -32,6 +32,11 @@ describe 'sssd', :type => :class do
     it { should contain_file('/etc/sssd/sssd.conf').with_content(/enumerate = true/)}
   end
 
+  context 'setting ldap_pwd_policy' do
+    let(:params) { { :ldap_pwd_policy => 'none' } }
+    it { should contain_file('/etc/sssd/sssd.conf').with_content(/ldap_pwd_policy = none/)}
+  end
+
   context 'setting filter_groups' do
     let(:params) { { :filter_groups => 'foo,bar' } }
     it { should contain_file('/etc/sssd/sssd.conf').with_content(/filter_groups = foo,bar/)}

--- a/templates/sssd.conf.erb
+++ b/templates/sssd.conf.erb
@@ -40,6 +40,6 @@ ldap_network_timeout = 3
 ldap_tls_reqcert = <%= scope.lookupvar('sssd::ldap_tls_reqcert') %>
 ldap_tls_cacert = <%= scope.lookupvar('sssd::ldap_tls_cacert') %>
 ldap_chpass_update_last_change = true
-ldap_pwd_policy = shadow
+ldap_pwd_policy = <%= scope.lookupvar('sssd::ldap_pwd_policy') %>
 ldap_account_expire_policy = shadow
 ldap_access_order = expire


### PR DESCRIPTION
ldap_pwd_policy is one more setting that my ldap environment needs to function with sssd.
I dare say that any additional sss/ldap configuration should probably be refactored into a sssd::ldap which is then concatenated into sssd.conf

I started looking at fixing the other tests but wasn't sure of the best approach.